### PR TITLE
feat: Morse::gpio_set_wpm(uint8_t the_wpm) added to change WPM

### DIFF
--- a/Morse.cpp
+++ b/Morse.cpp
@@ -187,6 +187,13 @@ Morse::gpio_tx(String tx)
 }
 
 void
+Morse::gpio_set_wpm(uint8_t the_wpm) {
+			gpio_wpm = the_wpm;
+			gpio_unit_t = UNIT_T(gpio_wpm);
+			gpio_inited = 1;
+}
+
+void
 gpio_handle_chars(void)
 {
 	gpio_tx_current_millis = millis();

--- a/Morse.h
+++ b/Morse.h
@@ -36,6 +36,7 @@ Morse
 		uint8_t gpio_transmitting(void);
 
 		void gpio_tx(String tx);
+		void gpio_set_wpm(uint8_t the_wpm);
 		void gpio_tx_stop(void);
 		void gpio_watchdog(void);
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ To enable the Morse Code, two watchdogs are available:
 		morse.gpio_watchdog();
 		morse_dac.dac_watchdog();
 
+To set the WPM for GPIO based Morse Code, use ```gpio_set_wpm``` function:
+
+		morse.gpio_set_wpm(new_wpm)
+		
+
 Example
 -------
 


### PR DESCRIPTION
Morse::gpio_set_wpm(uint8_t the_wpm) allows to change the WPM for GPIO based Morse Code.